### PR TITLE
fix mongodb edit exception

### DIFF
--- a/models/Dbopt.js
+++ b/models/Dbopt.js
@@ -76,10 +76,11 @@ var DbOpt = {
         if(shortid.isValid(targetId)){
             var conditions = {_id : targetId};
             req.body.updateDate = new Date();
+            delete req.body._id;
             var update = {$set : req.body};
             obj.update(conditions, update, function (err,result) {
                 if(err){
-                    res.end(err);
+                    res.end(err.message);
                 }else{
                     console.log(logMsg+" success!");
                     res.end("success");


### PR DESCRIPTION
when edit the data for mongdb, we should't include the id in the data. Or mongdb will return an error about that.

Also, for the end function, it expects a string but not a object.