### PR TITLE
修复表单验证中 当Input为Number类型的问题

### DIFF
--- a/src/manage/components/adminUser/userForm.vue
+++ b/src/manage/components/adminUser/userForm.vue
@@ -20,7 +20,7 @@
                     </el-select>
                 </el-form-item>
                 <el-form-item label="电话" prop="phoneNum">
-                    <el-input size="small" v-model="dialogState.formData.phoneNum"></el-input>
+                    <el-input size="small" v-model.number="dialogState.formData.phoneNum"></el-input>
                 </el-form-item>
                 <el-form-item label="邮箱" prop="email">
                     <el-input size="small" v-model="dialogState.formData.email"></el-input>
@@ -116,8 +116,9 @@ export default {
                     trigger: 'change'
                 }],
                 phoneNum: [{
+                    type: 'number',
                     required: true,
-                    message: '请输入正确的手机号',
+                    message: '请输入手机号',
                     trigger: 'blur'
                 }, {
                     validator: (rule, value, callback) => {

--- a/src/manage/components/regUser/userForm.vue
+++ b/src/manage/components/regUser/userForm.vue
@@ -12,7 +12,7 @@
                     <el-switch active-text="是" inactive-text="否" v-model="dialogState.formData.enable"></el-switch>
                 </el-form-item>
                 <el-form-item label="电话" prop="phoneNum">
-                    <el-input size="small" v-model="dialogState.formData.phoneNum"></el-input>
+                    <el-input size="small" v-model.number="dialogState.formData.phoneNum"></el-input>
                 </el-form-item>
                 <el-form-item label="邮箱" prop="email">
                     <el-input size="small" v-model="dialogState.formData.email"></el-input>
@@ -68,6 +68,8 @@ export default {
                     trigger: 'blur'
                 }],
                 phoneNum: [{
+                    type: 'number',
+                    required: true,
                     message: '请输入手机号',
                     trigger: 'blur'
                 }, {

--- a/utils/validatorUtil.js
+++ b/utils/validatorUtil.js
@@ -32,7 +32,7 @@ module.exports = {
     },
     // 校验手机号
     checkPhoneNum(str) {
-        return str && validator.isMobilePhone(str, 'zh-CN');
+        return str && validator.isMobilePhone(str.toString(), 'zh-CN');
     },
     // 校验QQ号
     checkQqNum(str) {


### PR DESCRIPTION
1. 修复表单验证中 当Input 为Number类型时 错误提示的问题 在 descriptor  添加 type: 'number' https://github.com/yiminghe/async-validator
2. 修复validator.js isMobilePhone 在传入Number类型时浏览器报错的问题 https://github.com/chriso/validator.js
3. 跟问题1 相对应 将用户的输入值转为 Number 类型 https://cn.vuejs.org/v2/guide/forms.html#number