### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ npm-debug.log
 admin.lock
 server/config/secret.js
 logs/
-dist/


### PR DESCRIPTION
dist目录被提交到了.gitignore中,因忽略了该目录,导致提交后服务端拉取缺少编译后的源文件,后台登录一片空白